### PR TITLE
Use name instead of firstname

### DIFF
--- a/app/controllers/spree/shipwire_webhook_controller.rb
+++ b/app/controllers/spree/shipwire_webhook_controller.rb
@@ -48,7 +48,7 @@ module Spree
     end
 
     def bin_secret
-      [Spree::ShipwireConfig.secret].pack('H*')
+      [::Spree::ShipwireConfig.secret].pack('H*')
     end
   end
 end

--- a/app/decorators/lib/solidus_shipwire/shipwire/api_decorator.rb
+++ b/app/decorators/lib/solidus_shipwire/shipwire/api_decorator.rb
@@ -3,7 +3,7 @@
 module SolidusShipwire
   module ApiDecorator
     def request(method, path, body: {}, params: {})
-      Shipwire::Request.send(method: method, path: full_path(path), body: body, params: params)
+      ::Shipwire::Request.send(method: method, path: full_path(path), body: body, params: params)
     end
 
     private
@@ -16,6 +16,6 @@ module SolidusShipwire
       "#{api_version}/#{path}"
     end
 
-    Shipwire::Api.prepend self
+    ::Shipwire::Api.prepend self
   end
 end

--- a/app/decorators/lib/solidus_shipwire/shipwire/orders_decorator.rb
+++ b/app/decorators/lib/solidus_shipwire/shipwire/orders_decorator.rb
@@ -23,6 +23,6 @@ module SolidusShipwire
       request(:post, "orders/#{id}/markComplete")
     end
 
-    Shipwire::Orders.prepend self
+    ::Shipwire::Orders.prepend self
   end
 end

--- a/app/decorators/lib/solidus_shipwire/shipwire/request_decorator.rb
+++ b/app/decorators/lib/solidus_shipwire/shipwire/request_decorator.rb
@@ -8,6 +8,6 @@ module SolidusShipwire
       "/api/#{@path}"
     end
 
-    Shipwire::Request.prepend self
+    ::Shipwire::Request.prepend self
   end
 end

--- a/app/decorators/lib/solidus_shipwire/shipwire/response_decorator.rb
+++ b/app/decorators/lib/solidus_shipwire/shipwire/response_decorator.rb
@@ -20,6 +20,6 @@ module SolidusShipwire
       resource[:classification] == "virtualKit"
     end
 
-    Shipwire::Response.prepend self
+    ::Shipwire::Response.prepend self
   end
 end

--- a/app/decorators/lib/solidus_shipwire/shipwire/stock_decorator.rb
+++ b/app/decorators/lib/solidus_shipwire/shipwire/stock_decorator.rb
@@ -6,6 +6,6 @@ module SolidusShipwire
       request(:post, 'stock/adjust', body: body)
     end
 
-    Shipwire::Stock.prepend self
+    ::Shipwire::Stock.prepend self
   end
 end

--- a/app/decorators/models/solidus_shipwire/spree/address_decorator.rb
+++ b/app/decorators/models/solidus_shipwire/spree/address_decorator.rb
@@ -6,6 +6,6 @@ module SolidusShipwire
       base.acts_as_shipwireable serializer: SolidusShipwire::AddressSerializer
     end
 
-    Spree::Address.prepend self
+    ::Spree::Address.prepend self
   end
 end

--- a/app/decorators/models/solidus_shipwire/spree/inventory_unit_decorator.rb
+++ b/app/decorators/models/solidus_shipwire/spree/inventory_unit_decorator.rb
@@ -6,6 +6,6 @@ module SolidusShipwire
       base.scope :eligible_for_shipwire, -> { joins(:variant).where.not(spree_variants: { shipwire_id: nil }) }
     end
 
-    Spree::InventoryUnit.prepend self
+    ::Spree::InventoryUnit.prepend self
   end
 end

--- a/app/decorators/models/solidus_shipwire/spree/manifest_item_decorator.rb
+++ b/app/decorators/models/solidus_shipwire/spree/manifest_item_decorator.rb
@@ -8,6 +8,6 @@ module SolidusShipwire
       base.acts_as_shipwireable serializer: SolidusShipwire::ShippingManifest::ManifestItemSerializer
     end
 
-    Spree::ShippingManifest::ManifestItem.prepend self
+    ::Spree::ShippingManifest::ManifestItem.prepend self
   end
 end

--- a/app/decorators/models/solidus_shipwire/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_shipwire/spree/order_decorator.rb
@@ -14,6 +14,6 @@ module SolidusShipwire
       end
     end
 
-    Spree::Order.prepend self
+    ::Spree::Order.prepend self
   end
 end

--- a/app/decorators/models/solidus_shipwire/spree/return_authorization_decorator.rb
+++ b/app/decorators/models/solidus_shipwire/spree/return_authorization_decorator.rb
@@ -7,7 +7,7 @@ module SolidusShipwire
     # order on shipwire, it should be splitter in more than one return
     # authorization, one for each of them.
     def self.prepended(base)
-      base.acts_as_shipwireable api_class: Shipwire::Returns,
+      base.acts_as_shipwireable api_class: ::Shipwire::Returns,
                                 serializer: SolidusShipwire::ReturnAuthorizationSerializer
 
       # At the moment the creation on shipwire has been removed, because the old
@@ -44,6 +44,6 @@ module SolidusShipwire
     #   end
     # end
 
-    Spree::ReturnAuthorization.prepend self
+    ::Spree::ReturnAuthorization.prepend self
   end
 end

--- a/app/decorators/models/solidus_shipwire/spree/shipment_decorator.rb
+++ b/app/decorators/models/solidus_shipwire/spree/shipment_decorator.rb
@@ -3,7 +3,7 @@
 module SolidusShipwire
   module ShipmentDecorator
     def self.prepended(base)
-      base.acts_as_shipwireable api_class: Shipwire::Orders,
+      base.acts_as_shipwireable api_class: ::Shipwire::Orders,
                                 serializer: SolidusShipwire::ShipmentSerializer
     end
 
@@ -12,9 +12,9 @@ module SolidusShipwire
     end
 
     def warehouse_id
-      Spree::ShipwireConfig.default_warehouse_id
+      ::Spree::ShipwireConfig.default_warehouse_id
     end
 
-    Spree::Shipment.prepend self
+    ::Spree::Shipment.prepend self
   end
 end

--- a/app/decorators/models/solidus_shipwire/spree/variant_decorator.rb
+++ b/app/decorators/models/solidus_shipwire/spree/variant_decorator.rb
@@ -3,10 +3,10 @@
 module SolidusShipwire
   module VariantDecorator
     def self.prepended(base)
-      base.acts_as_shipwireable api_class: Shipwire::Products,
+      base.acts_as_shipwireable api_class: ::Shipwire::Products,
                                 serializer: SolidusShipwire::VariantSerializer
     end
 
-    Spree::Variant.prepend self
+    ::Spree::Variant.prepend self
   end
 end

--- a/app/serializers/solidus_shipwire/address_serializer.rb
+++ b/app/serializers/solidus_shipwire/address_serializer.rb
@@ -7,7 +7,7 @@ module SolidusShipwire
     attribute :state_name, key: :state
     attribute :zipcode,    key: :postalCode
 
-    attribute(:name)    { "#{object.firstname} #{object.lastname}" }
+    attribute(:name)    { SolidusSupport.combined_first_and_last_name_in_address? ? object.name : object.full_name }
     attribute(:country) { object.country.iso }
   end
 end

--- a/app/serializers/solidus_shipwire/shipment_serializer.rb
+++ b/app/serializers/solidus_shipwire/shipment_serializer.rb
@@ -22,7 +22,7 @@ module SolidusShipwire
     end
 
     attribute(:items) do
-      Spree::ShippingManifest
+      ::Spree::ShippingManifest
         .new(inventory_units: object.inventory_units.eligible_for_shipwire)
         .items.map(&:to_shipwire_json)
     end

--- a/lib/solidus_shipwire/engine.rb
+++ b/lib/solidus_shipwire/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusShipwire
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace Spree
 

--- a/lib/solidus_shipwire/engine.rb
+++ b/lib/solidus_shipwire/engine.rb
@@ -16,11 +16,11 @@ module SolidusShipwire
     end
 
     initializer 'solidus_shipwire.environment', before: 'spree.environment' do
-      Spree::ShipwireConfig = Spree::ShipwireConfiguration.new
+      ::Spree::ShipwireConfig = ::Spree::ShipwireConfiguration.new
     end
 
     initializer 'solidus_shipwire.environment', after: 'finisher_hook' do
-      Spree::ShipwireConfig.setup_shipwire
+      ::Spree::ShipwireConfig.setup_shipwire
     end
   end
 end

--- a/lib/solidus_shipwire/shipwireable/shipwire_api.rb
+++ b/lib/solidus_shipwire/shipwireable/shipwire_api.rb
@@ -23,7 +23,7 @@ module SolidusShipwire
         def configure_shipwire_api_class
           shipwire_api_class = shipwireable_config[:api_class]
 
-          if shipwire_api_class.nil? || !shipwire_api_class.ancestors.include?(Shipwire::Api)
+          if shipwire_api_class.nil? || !shipwire_api_class.ancestors.include?(::Shipwire::Api)
             raise ArgumentError, "shipwire_api_class is not set or doesn't inherit from Shipwire::Api"
           end
 

--- a/solidus_shipwire.gemspec
+++ b/solidus_shipwire.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord', ['>= 4.0']
   s.add_dependency 'retriable'
   s.add_dependency 'shipwire', '~> 2.0'
-  s.add_dependency 'solidus_support', '~> 0.4.0'
+  s.add_dependency 'solidus_support', '>= 0.4', '< 0.9'
 
   s.add_development_dependency 'solidus_dev_support'
   s.add_development_dependency 'vcr'

--- a/spec/models/spree/return_authorization_spec.rb
+++ b/spec/models/spree/return_authorization_spec.rb
@@ -15,7 +15,7 @@ xdescribe Spree::ReturnAuthorization, type: :model do
   end
 
   before do
-    Spree::ShipwireConfig.default_warehouse_id = default_warehouse['id']
+    ::Spree::ShipwireConfig.default_warehouse_id = default_warehouse['id']
   end
 
   describe "order in pending state",

--- a/spec/serializers/solidus_shipwire/address_serializer_spec.rb
+++ b/spec/serializers/solidus_shipwire/address_serializer_spec.rb
@@ -7,10 +7,13 @@ describe SolidusShipwire::AddressSerializer do
     subject { described_class.new(address).as_json(include: '**') }
 
     let!(:address) { create(:address) }
+    let(:expected_name) do
+      SolidusSupport.combined_first_and_last_name_in_address? ? address.name : address.full_name
+    end
 
     it "is formatted as shipwire json" do
       expect(subject).to include(
-        name: "#{address.firstname} #{address.lastname}",
+        name: expected_name,
         company: address.company,
         address1: address.address1,
         address2: address.address2,

--- a/spec/serializers/solidus_shipwire/shipment_serializer_spec.rb
+++ b/spec/serializers/solidus_shipwire/shipment_serializer_spec.rb
@@ -19,7 +19,7 @@ describe SolidusShipwire::ShipmentSerializer do
     end
 
     let(:items_json_node) do
-      Spree::ShippingManifest
+      ::Spree::ShippingManifest
         .new(inventory_units: shipment.inventory_units.eligible_for_shipwire)
         .items.map(&:to_shipwire_json)
     end

--- a/spec/support/helpers/shipwire_hacks.rb
+++ b/spec/support/helpers/shipwire_hacks.rb
@@ -19,7 +19,7 @@ module ShipwireHacks
     def signature(data)
       OpenSSL::HMAC.hexdigest(
         OpenSSL::Digest.new('sha256'),
-        [Spree::ShipwireConfig.secret].pack('H*'),
+        [::Spree::ShipwireConfig.secret].pack('H*'),
         data
       )
     end


### PR DESCRIPTION
The `firstname` field is getting removed from Solidus 3.0, so we need to move to using `name` instead. This worked well here because all the serializer needed was a single name anyways.

This should complete #25 